### PR TITLE
+added second type for argument

### DIFF
--- a/src/Common/ApiAbstract.php
+++ b/src/Common/ApiAbstract.php
@@ -51,7 +51,7 @@ abstract class ApiAbstract {
     /**
      * Get single item
      *
-     * @param  int $id
+     * @param  int|string $id Id can be Subscribers ID or his email address
      * @return [type]
      */
     public function find($id)


### PR DESCRIPTION
I think specification has changed or you just forget to put this into comment. ApiAbstract->find($id) function can take also string of Email address of the subscriber. I thought it's important to note this in comment because just skipped this function while searching for smth. that will get me single Subscriber by email address, but finally I tried ->find(int $id) for Email and it worked. ;)